### PR TITLE
Add gpg-check to user_install recipe.

### DIFF
--- a/recipes/user_install.rb
+++ b/recipes/user_install.rb
@@ -26,6 +26,27 @@ node["rvm"]["installs"].each do |user, opts|
   # if user hash is not a hash (i.e. set to true), init an empty Hash
   opts = Hash.new if opts == true
 
+  ruby_block 'Conditionally add RVM gpg key' do
+    block do
+      cmd = Mixlib::ShellOut.new('which gpg2 || which gpg')
+      cmd.run_command
+
+      if cmd.exitstatus == 0
+        gpg_command = cmd.stdout.chomp
+
+        exec = Chef::Resource::Execute.new 'Add RVM gpg key', run_context
+        exec.command "#{gpg_command} --keyserver hkp://keys.gnupg.net --recv-keys #{node['rvm']['gpg_key']}"
+        exec.user rvm_user['user']
+        exec.environment 'HOME' => rvm_prefix
+        exec.guard_interpreter :bash
+        exec.not_if "#{gpg_command} -k #{node['rvm']['gpg_key']} > /dev/null", user: rvm_user['user'], environment: { 'HOME' => rvm_prefix }
+        exec.run_action :run
+      else
+        Chef::Log.info 'Skipping adding RVM key because gpg/gpg2 not installed'
+      end
+    end
+  end
+
   rvm_installation(user.to_s) do
     %w(installer_url installer_flags install_pkgs rvmrc_template_source
       rvmrc_template_cookbook rvmrc_env action

--- a/recipes/user_install.rb
+++ b/recipes/user_install.rb
@@ -26,7 +26,7 @@ node["rvm"]["installs"].each do |user, opts|
   # if user hash is not a hash (i.e. set to true), init an empty Hash
   opts = Hash.new if opts == true
 
-  ruby_block 'Conditionally add RVM gpg key' do
+  ruby_block "Conditionally add RVM gpg key #{user}" do
     block do
       cmd = Mixlib::ShellOut.new('which gpg2 || which gpg')
       cmd.run_command


### PR DESCRIPTION
RVM fails on machines with gpg installed. It checks for the
existence of gpg on the system in a ruby_block and imports the . This will allow for some
code reuse for the LWRP release.