### PR TITLE
Moved node['rvm']['gpg'] to a separate variable

### DIFF
--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -30,8 +30,10 @@ if node['rvm']['group_id'] != 'default'
   g.run_action(:create)
 end
 
-key_server = node['rvm']['gpg']['keyserver'] || "hkp://keys.gnupg.net"
-home_dir = "#{node['rvm']['gpg']['homedir'] || '~'}/.gnupg"
+node_gpg = node['rvm']['gpg'] || {}
+
+key_server = node_gpg['keyserver'] || "hkp://keys.gnupg.net"
+home_dir = "#{node_gpg['homedir'] || '~'}/.gnupg"
 
 execute 'Adding gpg key' do
   command "`which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"


### PR DESCRIPTION
Fixes #307. 

If `node['rvm']['gpg']` was undefined, the default settings such as "hkp://keys.gnupg.net" would never get set in `system_install.rb`. This sets a variable, `node_gpg`, to either `node['rvm']['gpg']` (if it exists) or an empty hash `{}` if it doesn't. This way, the default values will be inserted, as the calls to `['keyserver']` and `['homedir']` will return `nil` rather than erroring out with a `NoMethodError`.
