### PR TITLE
Updated the RVM GPG key to match the one in RVM's install instructions

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,7 +54,7 @@ default['rvm']['group_id']      = 'default'
 default['rvm']['group_users']   = []
 
 # GPG key for rvm verification
-default['rvm']['gpg_key']       = 'D39DC0E3'
+default['rvm']['gpg_key']       = '409B6B1796C275462A1703113804BB82D39DC0E3'
 
 case platform
 when "redhat","centos","fedora","scientific","amazon"


### PR DESCRIPTION
RVM appears to have updated the GPG key it retrieves from keys.gnupg.net in their install instructions at https://rvm.io/. This commit updates the GPG key in `default.rb` to match.
