### PR TITLE
Update travis testing stack.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,8 @@ rvm:
   - 2.1.2
   - 2.2.0
 bundler_args: --without integration development
+before_script:
+  -bundle exec berks install
+script:
+  - bundle exec rake unit
+  - bundle exec rake foodcritic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3-p547
+  - 2.0.0
+  - 2.1.2
+  - 2.2.0
 bundler_args: --without integration development

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ rvm:
   - 2.1.2
   - 2.2.0
 bundler_args: --without integration development
-before_script:
-  -bundle exec berks install
 script:
   - bundle exec rake unit
   - bundle exec rake foodcritic

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# <a name="title"></a> chef-rvm [![Build Status](https://secure.travis-ci.org/fnichol/chef-rvm.png?branch=master)](http://travis-ci.org/fnichol/chef-rvm)
+# <a name="title"></a> chef-rvm [![Build
+Status](https://secure.travis-ci.org/martinisoft/chef-rvm.png?branch=master)](http://travis-ci.org/martinisoft/chef-rvm)
 
 ## <a name="description"></a> Description
 


### PR DESCRIPTION
I added a couple of ruby versions that I think are safe for us to test
against. I considered keeping 1.9.3 for backwards-compat testing, but
since 1.9.3 support isn't given upstream, I think it is best to just
remove it.