### PR TITLE
Add class_variable_set method for root_rvm_path to fix warning

### DIFF
--- a/libraries/rvm_chef_user_environment.rb
+++ b/libraries/rvm_chef_user_environment.rb
@@ -46,7 +46,7 @@ def create_rvm_chef_user_environment
     end
 
     def self.root_rvm_path=(path)
-      @@root_rvm_path = path
+      class_variable_set(:@@root_rvm_path, path)
     end
   end
   ::RVM.const_set('ChefUserEnvironment', klass)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.10.1"
+version           "0.10.2"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."


### PR DESCRIPTION
In order to get rid of the warning about `class variable access from
toplevel`, this commit adds the class_variable_set for root_rvm_path.