### PR TITLE
Do not try to download and install Papis GPG Key on every chef run

### DIFF
--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -36,7 +36,7 @@ home_dir = "#{node['rvm']['gpg']['homedir'] || '~'}/.gnupg"
 execute 'Adding gpg key' do
   command "`which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"
   only_if 'which gpg2 || which gpg'
-  not_if { node['rvm']['gpg_key'].empty? }
+  not_if "[ -n '#{node['rvm']['gpg_key']}' ] && `which gpg2 || which gpg` -k #{node['rvm']['gpg_key']} > /dev/null"
 end
 
 rvm_installation("root")


### PR DESCRIPTION
If using rvm::system  recipe, it tries to download GPG keys on every chef run, this patch just check if the key is already present.