### PR TITLE
fix: cheffile declaration outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Include a reference to the cookbook in a [Cheffile][cheffile] and run
     librarian-chef init
     cat >> Cheffile <<END_OF_CHEFFILE
     cookbook 'rvm',
-      :git => 'git://github.com/fnichol/chef-rvm.git', :ref => 'v0.9.0'
+      :git => 'git://github.com/fnichol/chef-rvm.git', :ref => 'v0.10.1'
     END_OF_CHEFFILE
     librarian-chef install
 


### PR DESCRIPTION
Since the chef version 12 has been released, the metadata should have 'name' property (https://github.com/chef/chef/issues/2435). I noticed that it was fixed in version 0.10.1, but README.md still point to v0.9.0.