### PR TITLE
Tests and linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Berksfile.lock
 .kitchen.local.yml
 .bundle/
 tmp/
+.idea

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,8 +20,8 @@
 #
 
 # ruby that will get installed and set to `rvm use default`.
-default['rvm']['default_ruby']      = "ruby-1.9.3-p547"
-default['rvm']['user_default_ruby'] = "ruby-1.9.3-p547"
+default['rvm']['default_ruby']      = 'ruby-1.9.3-p547'
+default['rvm']['user_default_ruby'] = 'ruby-1.9.3-p547'
 
 # list of additional rubies that will be installed
 default['rvm']['rubies']      = []
@@ -39,14 +39,14 @@ default['rvm']['gems']      = Hash.new
 default['rvm']['user_gems'] = Hash.new
 
 # hash of rvmrc options
-default['rvm']['rvmrc_env'] = { "rvm_gem_options" => "--no-ri --no-rdoc" }
+default['rvm']['rvmrc_env'] = { 'rvm_gem_options' => '--no-ri --no-rdoc' }
 
 # a hash of user hashes, each an isolated per-user RVM installation
 default['rvm']['installs'] = Hash.new
 
 # system-wide installer options
-default['rvm']['installer_url']   = "https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer"
-default['rvm']['version'] = "stable"
+default['rvm']['installer_url']   = 'https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer'
+default['rvm']['version'] = 'stable'
 
 # GPG key for rvm verification
 default['rvm']['gpg_key']        = 'D39DC0E3'
@@ -56,17 +56,17 @@ default['rvm']['gpg_key_server'] = 'hkp://keys.gnupg.net'
 default['rvm']['autolib_mode'] = 3
 
 # extra system-wide tunables
-default['rvm']['root_path']     = "/usr/local/rvm"
+default['rvm']['root_path']     = '/usr/local/rvm'
 default['rvm']['group_id']      = 'default'
 default['rvm']['group_users']   = []
 
 case platform
-when "redhat","centos","fedora","scientific","amazon"
+when 'redhat','centos','fedora','scientific','amazon'
   node.set['rvm']['install_pkgs']   = %w{sed grep tar gzip bzip2 bash curl git}
-when "debian","ubuntu","suse"
+when 'debian','ubuntu','suse'
   node.set['rvm']['install_pkgs']   = %w{sed grep tar gzip bzip2 bash curl git-core}
-when "gentoo"
+when 'gentoo'
   node.set['rvm']['install_pkgs']   = %w{git}
-when "mac_os_x", "mac_os_x_server"
+when 'mac_os_x', 'mac_os_x_server'
   node.set['rvm']['install_pkgs']   = %w{git}
 end

--- a/attributes/vagrant.rb
+++ b/attributes/vagrant.rb
@@ -19,5 +19,5 @@
 # limitations under the License.
 #
 
-default['rvm']['vagrant']['system_chef_client'] = "/opt/vagrant_ruby/bin/chef-client"
-default['rvm']['vagrant']['system_chef_solo'] = "/opt/vagrant_ruby/bin/chef-solo"
+default['rvm']['vagrant']['system_chef_client'] = '/opt/vagrant_ruby/bin/chef-client'
+default['rvm']['vagrant']['system_chef_solo'] = '/opt/vagrant_ruby/bin/chef-solo'

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,6 @@
+
+if defined?(ChefSpec)
+  def install_rvm_ruby(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:rvm_ruby, :install, resource_name)
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,31 +1,31 @@
-name              "rvm"
-maintainer        "Aaron Kalin"
-maintainer_email  "akalin@martinisoftware.com"
-license           "Apache 2.0"
-description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
+name              'rvm'
+maintainer        'Aaron Kalin'
+maintainer_email  'akalin@martinisoftware.com'
+license           'Apache 2.0'
+description       'Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs.'
 long_description  "Please refer to README.md (it's long)."
-version           "0.10.1"
-source_url        "https://github.com/martinisoft/chef-rvm"
-issues_url        "https://github.com/martinisoft/chef-rvm/issues"
+version           '0.10.1'
+source_url        'https://github.com/martinisoft/chef-rvm'
+issues_url        'https://github.com/martinisoft/chef-rvm/issues'
 
-recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
-recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."
-recipe "rvm::system",         "Installs the RVM codebase system-wide (that is, into /usr/local/rvm) and installs Rubies, global gems, and specific gems driven off attribute metadata. This recipe includes *default* and *system_install*. Use this recipe by itself if you want RVM system-wide with Rubies installed, etc."
-recipe "rvm::user_install", "Installs the RVM codebase for a list of users (selected from the node['rvm']['user_installs'] hash). This recipe includes *default*. Use this recipe by itself if you want RVM installed for specific users in isolation but want each user to handle installing Rubies, invoking LWRPs, etc."
-recipe "rvm::user",            "Installs the RVM codebase for a list of users (selected from the node['rvm']['user_installs'] hash) and installs Rubies, global gems, and specific gems driven off attribute metadata. This recipe includes *default* and *user_install*. Use this recipe by itself if you want RVM installed for specific users in isolation with Rubies installed, etc."
-recipe "rvm::vagrant",      "An optional recipe to help if running in a Vagrant virtual machine"
-recipe "rvm::gem_package",  "An experimental recipe that patches the gem_package resource"
+recipe 'rvm',                 'Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided.'
+recipe 'rvm::system_install', 'Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc..'
+recipe 'rvm::system',         'Installs the RVM codebase system-wide (that is, into /usr/local/rvm) and installs Rubies, global gems, and specific gems driven off attribute metadata. This recipe includes *default* and *system_install*. Use this recipe by itself if you want RVM system-wide with Rubies installed, etc.'
+recipe 'rvm::user_install', "Installs the RVM codebase for a list of users (selected from the node['rvm']['user_installs'] hash). This recipe includes *default*. Use this recipe by itself if you want RVM installed for specific users in isolation but want each user to handle installing Rubies, invoking LWRPs, etc."
+recipe 'rvm::user',            "Installs the RVM codebase for a list of users (selected from the node['rvm']['user_installs'] hash) and installs Rubies, global gems, and specific gems driven off attribute metadata. This recipe includes *default* and *user_install*. Use this recipe by itself if you want RVM installed for specific users in isolation with Rubies installed, etc."
+recipe 'rvm::vagrant',      'An optional recipe to help if running in a Vagrant virtual machine'
+recipe 'rvm::gem_package',  'An experimental recipe that patches the gem_package resource'
 
 # provides chef_gem resource to chef <= 0.10.8 and fixes for chef < 10.12.0
-depends "chef_gem"
+depends 'chef_gem'
 
-supports "debian"
-supports "ubuntu"
-supports "suse"
-supports "centos"
-supports "amazon"
-supports "redhat"
-supports "fedora"
-supports "gentoo"
-supports "mac_os_x"
-supports "mac_os_x_server"
+supports 'debian'
+supports 'ubuntu'
+supports 'suse'
+supports 'centos'
+supports 'amazon'
+supports 'redhat'
+supports 'fedora'
+supports 'gentoo'
+supports 'mac_os_x'
+supports 'mac_os_x_server'

--- a/recipes/gem_package.rb
+++ b/recipes/gem_package.rb
@@ -20,14 +20,14 @@
 node_val = node['rvm']['gem_package']['rvm_string']
 case node_val
 when String
-  rvm_descriptor = node_val + " RVM Ruby"
+  rvm_descriptor = node_val + ' RVM Ruby'
 when Array
   last = node_val.pop
-  rvm_descriptor = [ node_val.join(', '), last ].join(' & ') + " RVM Rubies"
+  rvm_descriptor = [ node_val.join(', '), last ].join(' & ') + ' RVM Rubies'
 end
 
 patch_gem_package
 
-::Chef::Log.info "gem_package resource has been patched to use provider " <<
-  "Chef::Provider::Package::RVMRubygems and will install gems to " <<
+::Chef::Log.info 'gem_package resource has been patched to use provider ' <<
+  'Chef::Provider::Package::RVMRubygems and will install gems to ' <<
   "the #{rvm_descriptor}."

--- a/recipes/system.rb
+++ b/recipes/system.rb
@@ -17,16 +17,16 @@
 # limitations under the License.
 #
 
-include_recipe "rvm::system_install"
+include_recipe 'rvm::system_install'
 
 perform_install_rubies  = node['rvm']['install_rubies'] == true ||
-                  node['rvm']['install_rubies'] == "true"
+                  node['rvm']['install_rubies'] == 'true'
 
 if perform_install_rubies
-  install_rubies  :rubies => node['rvm']['rubies'],
-                  :default_ruby => node['rvm']['default_ruby'],
-                  :global_gems => node['rvm']['global_gems'],
-                  :gems => node['rvm']['gems']
+  install_rubies  rubies: node['rvm']['rubies'],
+                  default_ruby: node['rvm']['default_ruby'],
+                  global_gems: node['rvm']['global_gems'],
+                  gems: node['rvm']['gems']
 end
 
 # add users to rvm group

--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -30,7 +30,7 @@ if node['rvm']['group_id'] != 'default'
   g.run_action(:create)
 end
 
-key_server = node['rvm']['gpg']['keyserver'] || "hkp://keys.gnupg.net"
+key_server = node['rvm']['gpg']['keyserver'] || 'hkp://keys.gnupg.net'
 home_dir = "#{node['rvm']['gpg']['homedir'] || '~'}/.gnupg"
 
 execute 'Adding gpg key' do
@@ -39,4 +39,4 @@ execute 'Adding gpg key' do
   not_if { node['rvm']['gpg_key'].empty? }
 end
 
-rvm_installation("root")
+rvm_installation('root')

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -21,9 +21,9 @@ include_recipe 'rvm::user_install'
 
 Array(node['rvm']['user_installs']).each do |rvm_user|
   perform_install_rubies  = rvm_user['install_rubies'] == true ||
-                            rvm_user['install_rubies'] == "true" ||
+                            rvm_user['install_rubies'] == 'true' ||
                             node['rvm']['user_install_rubies'] == true ||
-                            node['rvm']['user_install_rubies'] == "true"
+                            node['rvm']['user_install_rubies'] == 'true'
   rubies                  = rvm_user['rubies'] ||
                             node['rvm']['user_rubies']
   default_ruby            = rvm_user['default_ruby'] ||
@@ -34,10 +34,10 @@ Array(node['rvm']['user_installs']).each do |rvm_user|
                             node['rvm']['user_gems']
 
   if perform_install_rubies
-    install_rubies  :rubies => rubies,
-                    :default_ruby => default_ruby,
-                    :global_gems => global_gems,
-                    :gems => gems,
-                    :user => rvm_user['user']
+    install_rubies  rubies: rubies,
+                    default_ruby: default_ruby,
+                    global_gems: global_gems,
+                    gems: gems,
+                    user: rvm_user['user']
   end
 end

--- a/recipes/user_install.rb
+++ b/recipes/user_install.rb
@@ -17,16 +17,16 @@
 # limitations under the License.
 #
 
-include_recipe "rvm"
+include_recipe 'rvm'
 
-node["rvm"]["installs"].each do |user, opts|
+node['rvm']['installs'].each do |user, opts|
   # if user hash is falsy (nil, false) then we're not installing
   next unless opts
 
   # if user hash is not a hash (i.e. set to true), init an empty Hash
   opts = Hash.new if opts == true
 
-  ruby_block "Conditionally add RVM gpg key" do # ~FC022 this will be fixed in the LWRP rewrite
+  ruby_block 'Conditionally add RVM gpg key' do # ~FC022 this will be fixed in the LWRP rewrite
     block do
       cmd = Mixlib::ShellOut.new('which gpg2 || which gpg')
       cmd.run_command

--- a/recipes/vagrant.rb
+++ b/recipes/vagrant.rb
@@ -17,21 +17,21 @@
 # limitations under the License.
 #
 
-template "/usr/local/bin/chef-client" do
-  source    "vagrant-chef-client-wrapper.erb"
-  owner     "root"
-  group     "root"
-  mode      "0755"
+template '/usr/local/bin/chef-client' do
+  source    'vagrant-chef-client-wrapper.erb'
+  owner     'root'
+  group     'root'
+  mode      '0755'
 end
 
-template "/usr/local/bin/chef-solo" do
-  source    "vagrant-chef-solo-wrapper.erb"
-  owner     "root"
-  group     "root"
-  mode      "0755"
+template '/usr/local/bin/chef-solo' do
+  source    'vagrant-chef-solo-wrapper.erb'
+  owner     'root'
+  group     'root'
+  mode      '0755'
 end
 
-group "rvm" do
-  members ["vagrant"]
+group 'rvm' do
+  members ['vagrant']
   append  true
 end

--- a/spec/libraries/resource_rvm_ruby_spec.rb
+++ b/spec/libraries/resource_rvm_ruby_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'rvm_ruby' do
+  let(:rvm_ruby_default) do
+    ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04',
+        step_into: ['rvm_ruby']
+    ).converge('rvm_wrapper::default')
+  end
+
+  context 'without rvm installed' do
+    it 'fetches the latest installer' do
+      expect(rvm_ruby_default).to install_rvm_ruby('2.3.0')
+    end
+  end
+end

--- a/test/integration/stock_system_and_user/minitest/Gemfile
+++ b/test/integration/stock_system_and_user/minitest/Gemfile
@@ -1,3 +1,3 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "mixlib-shellout"
+gem 'mixlib-shellout'

--- a/test/integration/stock_system_and_user/minitest/test_stock_system_and_user.rb
+++ b/test/integration/stock_system_and_user/minitest/test_stock_system_and_user.rb
@@ -1,48 +1,48 @@
-require "minitest/autorun"
-require "minitest/pride"
-require "mixlib/shellout"
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'mixlib/shellout'
 
-def exec_with_env(cmd, user="root")
+def exec_with_env(cmd, user='root')
   home_dir = etc_user(user).dir
   opts = {
-    :user => user,
-    :group => etc_user(user).gid,
-    :cwd => home_dir,
-    :env => { "HOME" => home_dir,
-              "USER" => user,
-              "TERM" => "dumb" }
+    user: user,
+    group: etc_user(user).gid,
+    cwd: home_dir,
+    env: { 'HOME' => home_dir,
+              'USER' => user,
+              'TERM' => 'dumb' }
   }
   exec_cmd = Mixlib::ShellOut.new(%{#{cmd}}, opts)
   exec_cmd.run_command
   exec_cmd
 end
 
-def exec_with_rvm(cmd, user="root")
+def exec_with_rvm(cmd, user='root')
   exec_with_env(%{#{rvm_path(user)}/bin/rvm #{cmd}}, user)
 end
 
-def rvm_path(user="root")
-  if user == "root"
-    "/usr/local/rvm"
+def rvm_path(user='root')
+  if user == 'root'
+    '/usr/local/rvm'
   else
-    ::File.join(etc_user(user).dir, ".rvm")
+    ::File.join(etc_user(user).dir, '.rvm')
   end
 end
 
-def etc_user(user="root")
+def etc_user(user='root')
   Etc.getpwnam(user)
 end
 
-describe "A system installation" do
-  it "creates a system install RVM directory" do
-    assert File.exists?("/usr/local/rvm")
+describe 'A system installation' do
+  it 'creates a system install RVM directory' do
+    assert File.exists?('/usr/local/rvm')
   end
 
-  it "sources into environment" do
+  it 'sources into environment' do
     assert_nil exec_with_env("bash -lc 'type rvm 1>/dev/null 2>&1'").error!
   end
 
-  it "installs 2.1.3" do
-    assert_match(/2\.1\.3/,exec_with_rvm("list strings", "wigglebottom").stdout)
+  it 'installs 2.1.3' do
+    assert_match(/2\.1\.3/,exec_with_rvm('list strings', 'wigglebottom').stdout)
   end
 end


### PR DESCRIPTION
I have run `rubocop --auto-correct` on the files in the cookbook and wrote the matchers.rb file to test the resource_rvm_ruby.rb file with the fixtures setup.

@martinisoft, if you can throw the helpers back in, I can help make some more headway on writing chefspec unit against the main recipes.

Looking for suggestions or ideas for `rvm_shell_chef_wrapper.rb` to toss the inheritance of the rvm gem so we can remove the chicken and egg problem and isolate the cookbook.
